### PR TITLE
[FEATURE] Guild Bans -> Guild Moderation Intent

### DIFF
--- a/src/main/java/com/seailz/discordjv/model/application/Intent.java
+++ b/src/main/java/com/seailz/discordjv/model/application/Intent.java
@@ -10,7 +10,7 @@ public enum Intent {
 
     GUILDS(0, false),
     GUILD_MEMBERS(1, true),
-    GUILD_BANS(2, false),
+    GUILD_MODERATION(2, false),
     GUILD_EMOJIS_AND_STICKERS(3, false),
     GUILD_INTEGRATIONS(4, false),
     GUILD_WEBHOOKS(5, false),


### PR DESCRIPTION
## Pull Request

- [x] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [ ] Internal code
- [x] Library
- [ ] Documentation

<!-- Replace 0 with the issue to close that is linked to this PR (if there is one) -->
Closes #110 

## Description
https://github.com/discord/discord-api-docs/pull/5849
Renamed `GUILD_BANS` to `GUILD_MODERATION`.
The PR in the docs repo is for a new audit log event, which will be covered by #30. They also renamed the intent, which is what is getting done in this PR.

# BREAKING CHANGES
| Before  | After |
| ------------- | ------------- |
| `Intent.GUILD_BANS`  | `Intent.GUILD_MODERATION`  |