### PR TITLE
[FIX] Fixed command listeners registered with the event system not dispatching correctly.

### DIFF
--- a/src/main/java/com/seailz/discordjar/command/CommandDispatcher.java
+++ b/src/main/java/com/seailz/discordjar/command/CommandDispatcher.java
@@ -44,7 +44,7 @@ public class CommandDispatcher {
 
     public void dispatch(String name, CommandInteractionEvent event) {
         Class<? extends CommandInteractionEvent> eventClass = (event instanceof SlashCommandInteractionEvent ? SlashCommandInteractionEvent.class : CommandInteractionEvent.class);
-        new EventDispatcher(event.getBot()).dispatchEvent(event, eventClass, event.getBot());
+        event.getBot().getEventDispatcher().dispatchEvent(event, eventClass, event.getBot());
         if ((event instanceof SlashCommandInteractionEvent) && ((SlashCommandInteractionEvent) event).getOptionsInternal() != null && !((SlashCommandInteractionEvent) event).getOptionsInternal().isEmpty()) {
             for (ResolvedCommandOption option : ((SlashCommandInteractionEvent) event).getOptionsInternal()) {
                 if (option.type() == CommandOptionType.SUB_COMMAND) {


### PR DESCRIPTION

## Pull Request

- [x] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [x] Internal code
- [ ] Library
- [ ] Documentation

<!-- Replace 0 with the issue to close that is linked to this PR (if there is one) -->
Closes #0

## Description
Fixed command listeners registered with the event system not dispatching as the command dispatch method was creating a new instance of the EventDispatcher class instead of using the one provided by the DiscordJar class