### PR TITLE
fix(commands): fixed default command perms not necessarily being set correctly

### DIFF
--- a/src/main/java/com/seailz/discordjar/command/Command.java
+++ b/src/main/java/com/seailz/discordjar/command/Command.java
@@ -59,7 +59,7 @@ public record Command(
         int permissions = -1;
         if (defaultMemberPermissions.length >= 1) permissions = 0;
         for (Permission permission : defaultMemberPermissions) {
-            permissions |= permission.code();
+            permissions |= (1 << permission.code());
         }
 
         JSONObject obj = new JSONObject()


### PR DESCRIPTION
## Pull Request

- [x] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [x] Internal code
- [ ] Library
- [ ] Documentation

<!-- Replace 0 with the issue to close that is linked to this PR (if there is one) -->
Closes #183 

## Description
fixed default command perms not necessarily being set correctly