### PR TITLE
feat(gateway): bot custom status support

### DIFF
--- a/src/main/java/com/seailz/discordjar/model/status/Status.java
+++ b/src/main/java/com/seailz/discordjar/model/status/Status.java
@@ -31,6 +31,13 @@ public record Status(
             activities.put(activity.compile());
         }
 
+        System.out.println(
+                new JSONObject()
+                        .put("since", since == 0 ? JSONObject.NULL : since)
+                        .put("activities", activities)
+                        .put("status", status.getCode())
+                        .put("afk", afk).toString(4)
+        );
         return new JSONObject()
                 .put("since", since == 0 ? JSONObject.NULL : since)
                 .put("activities", activities)

--- a/src/main/java/com/seailz/discordjar/model/status/Status.java
+++ b/src/main/java/com/seailz/discordjar/model/status/Status.java
@@ -31,13 +31,6 @@ public record Status(
             activities.put(activity.compile());
         }
 
-        System.out.println(
-                new JSONObject()
-                        .put("since", since == 0 ? JSONObject.NULL : since)
-                        .put("activities", activities)
-                        .put("status", status.getCode())
-                        .put("afk", afk).toString(4)
-        );
         return new JSONObject()
                 .put("since", since == 0 ? JSONObject.NULL : since)
                 .put("activities", activities)

--- a/src/main/java/com/seailz/discordjar/model/status/activity/Activity.java
+++ b/src/main/java/com/seailz/discordjar/model/status/activity/Activity.java
@@ -20,6 +20,7 @@ public class Activity implements Compilerable {
 
     private final String name;
     private final ActivityType type;
+    private String state;
 
     private String streamUrl;
     private String applicationId;
@@ -32,6 +33,24 @@ public class Activity implements Compilerable {
         this.type = type;
     }
 
+    /**
+     * Allows a bot to define a custom status.
+     * Please note: Emojis are not supported in custom statuses for bots.
+     */
+    public Activity(String customStatus) {
+        this(customStatus, ActivityType.CUSTOM);
+        setState(customStatus);
+    }
+
+    /**
+     * If you've selected an Activity Type that's not 4 (custom), you can set the state as extra info to your activity.
+     *  User's current party status.
+     */
+    public Activity setState(String state) {
+        this.state = state;
+        return this;
+    }
+
     public Activity setStreamUrl(String url) {
         this.streamUrl = url;
         return this;
@@ -39,11 +58,6 @@ public class Activity implements Compilerable {
 
     public Activity setApplicationId(String applicationId) {
         this.applicationId = applicationId;
-        return this;
-    }
-
-    public Activity setEmoji(Emoji emoji) {
-        this.emoji = emoji;
         return this;
     }
 
@@ -57,6 +71,11 @@ public class Activity implements Compilerable {
         return this;
     }
 
+    public Activity setEmoji(Emoji emoji) {
+        this.emoji = emoji;
+        return this;
+    }
+
     public String name() {
         return name;
     }
@@ -64,6 +83,7 @@ public class Activity implements Compilerable {
     public ActivityType type() {
         return type;
     }
+    public String state() { return state; }
 
     public String streamUrl() {
         return streamUrl;
@@ -94,7 +114,7 @@ public class Activity implements Compilerable {
                 .put("application_id", applicationId)
                 .put("emoji", emoji == null ? JSONObject.NULL : emoji.compile())
                 .put("instance", instance)
-                .put("flags", flags == null ? JSONObject.NULL : new JSONObject().put("flags", flags));
+                .put("state", state);
     }
 
     @NotNull
@@ -103,6 +123,7 @@ public class Activity implements Compilerable {
         ActivityType type;
         String url;
         String applicationId;
+        String state;
         Emoji emoji;
         boolean instance;
         EnumSet<ActivityFlags> flags;
@@ -127,6 +148,10 @@ public class Activity implements Compilerable {
 
         if (obj.has("flags")) flags = ActivityFlags.fromInt(obj.getInt("flags"));
         else flags = null;
+
+        if (obj.has("state")) state = obj.getString("state");
+        else state = null;
+
 
         return new Activity(name, type)
                 .setStreamUrl(url)

--- a/src/main/java/com/seailz/discordjar/utils/StatusRotor.java
+++ b/src/main/java/com/seailz/discordjar/utils/StatusRotor.java
@@ -1,0 +1,82 @@
+package com.seailz.discordjar.utils;
+
+import com.seailz.discordjar.DiscordJar;
+import com.seailz.discordjar.model.status.Status;
+
+import java.util.List;
+
+/**
+ * Simple util for a status rotor - switches between statuses every x seconds.
+ * @author Seailz
+ */
+public class StatusRotor {
+
+    private List<Status> statuses;
+    private long interval;
+    private DiscordJar dJar;
+    private boolean running;
+
+    /**
+     * Creates a new status rotor.
+     * Start the rotor by calling {@link #start()}
+     * @param status The statuses to rotate between
+     * @param interval The interval (in milliseconds) to switch between statuses
+     * @param dJar The DiscordJar instance
+     */
+    public StatusRotor(List<Status> status, long interval, DiscordJar dJar) {
+        this.statuses = status;
+        this.interval = interval;
+        this.dJar = dJar;
+
+        new Thread(() -> {
+            int index = 0;
+            while (true) {
+                if (!running) continue;
+                try {
+                    Thread.sleep(interval);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                if (!running) continue;
+                if (statuses == null) continue;
+                if (statuses.size() == 0) continue;
+
+                dJar.setStatus(statuses.get(index));
+                index++;
+                if (index >= statuses.size()) index = 0;
+            }
+        }, "Status Rotor").start();
+    }
+
+    /**
+     * Starts the rotor
+     */
+    public void start() {
+        this.running = true;
+    }
+
+    /**
+     * Stops the rotor
+     */
+    public void stop() {
+        this.running = false;
+    }
+
+    public DiscordJar getdJar() {
+        return dJar;
+    }
+
+    public List<Status> getStatuses() {
+        return statuses;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public StatusRotor addStatus(Status status) {
+        statuses.add(status);
+        return this;
+    }
+}


### PR DESCRIPTION
## Pull Request

- [x] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [x] Internal code
- [x] Library
- [ ] Documentation

<!-- Replace 0 with the issue to close that is linked to this PR (if there is one) -->
Closes #205 

## Description
https://github.com/discord/discord-api-docs/pull/6345
Bots can now set the `state` field in the activity object.