### PR TITLE
Java 21

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Setup Java Version
       uses: actions/setup-java@v1
       with:
-        java-version: 17       
+        java-version: 21
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 before_install:
-  - sdk install java 17.0.4-open
-  - sdk use java 17.0.4-open
+  - sdk install java 21-open
+  - sdk use java 21-open
 jdk:
-  - openjdk17
+  - openjdk21

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
     <version>b-1.1</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
 
     <build>
@@ -65,12 +65,6 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-        <!-- TODO: REMOVE -->
-        <repository>
-            <id>dv8tion</id>
-            <name>m2-dv8tion</name>
-            <url>https://m2.dv8tion.net/releases</url>
-        </repository>
     </repositories>
 
     <dependencies>
@@ -122,8 +116,8 @@
         <!-- Database API used for Linked Roles/OAuth2 token refreshing -->
         <dependency>
             <groupId>com.github.seailz</groupId>
-            <artifactId>databaseapi</artifactId>
-            <version>2.3</version>
+            <artifactId>Database4J</artifactId>
+            <version>02941e7bef</version>
         </dependency>
         <!-- Used for creating transcripts of channels -->
         <dependency>
@@ -144,7 +138,7 @@
         <dependency>
             <groupId>com.github.codahale</groupId>
             <artifactId>xsalsa20poly1305</artifactId>
-            <version>v0.10.1		</version>
+            <version>v0.10.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
             </resource>
         </resources>
     </build>
-
     <repositories>
         <repository>
             <id>jitpack.io</id>

--- a/src/main/java/com/seailz/discordjar/events/EventDispatcher.java
+++ b/src/main/java/com/seailz/discordjar/events/EventDispatcher.java
@@ -69,7 +69,7 @@ public class EventDispatcher {
      */
     public void dispatchEvent(Event event, Class<? extends Event> type, DiscordJar djv) {
         if (event == null) return;
-        new Thread(() -> {
+        DiscordJarThreadAllocator.requestVirtualThread(() -> {
             long start = System.currentTimeMillis();
             List<ListenerMethodPair> listenersForEventType = listenersByEventType.get(type);
             if (listenersForEventType == null) {
@@ -91,7 +91,7 @@ public class EventDispatcher {
                 }
 
                 method.setAccessible(true);
-                DiscordJarThreadAllocator.requestThread(() -> {
+                DiscordJarThreadAllocator.requestVirtualThread(() -> {
                     try {
                         method.invoke(listenerMethodPair.listener, event);
                     } catch (IllegalAccessException | ArrayIndexOutOfBoundsException e) {
@@ -102,8 +102,8 @@ public class EventDispatcher {
                         System.out.println(method.getDeclaringClass().getSimpleName() + "#" + method.getName() + " threw an exception while being invoked.");
                         e.getCause().printStackTrace();
                     }
-                }, "djar--EventDispatcher-inner").start();
+                }, "djar--EventDispatcher-inner");
             }
-        }, "djar--EventDispatcher").start();
+        }, "djar--EventDispatcher");
     }
 }

--- a/src/main/java/com/seailz/discordjar/events/EventDispatcher.java
+++ b/src/main/java/com/seailz/discordjar/events/EventDispatcher.java
@@ -103,6 +103,7 @@ public class EventDispatcher {
                         e.getCause().printStackTrace();
                     }
                 }, "djar--EventDispatcher-inner");
+
             }
         }, "djar--EventDispatcher");
     }

--- a/src/main/java/com/seailz/discordjar/utils/thread/DiscordJarThreadAllocator.java
+++ b/src/main/java/com/seailz/discordjar/utils/thread/DiscordJarThreadAllocator.java
@@ -31,6 +31,21 @@ public class DiscordJarThreadAllocator {
         return thread;
     }
 
+    public static Thread requestVirtualThread(Runnable runnable, String name) {
+        // First, let's check if we can actually use a virtual thread due to the JDK version.
+        int javaRelease = Integer.parseInt(System.getProperty("java.specification.version"));
+        if (javaRelease < 21) {
+            Logger.getLogger("discord.jar-threading")
+                    .warning("discord.jar virtual threads are only supported on JDK 21 and above, falling back to normal threads. It's recommended, if possible, that you upgrade your JDK to 21 or above.");
+            return requestThread(runnable, name);
+        }
+
+        Thread virtualThread = Thread.ofVirtual()
+                .start(runnable);
+        virtualThread.setName(name);
+        return virtualThread;
+    }
+
     private static void printThreads() {
         ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
 

--- a/src/main/java/com/seailz/discordjar/utils/thread/DiscordJarThreadAllocator.java
+++ b/src/main/java/com/seailz/discordjar/utils/thread/DiscordJarThreadAllocator.java
@@ -33,7 +33,14 @@ public class DiscordJarThreadAllocator {
 
     public static Thread requestVirtualThread(Runnable runnable, String name) {
         // First, let's check if we can actually use a virtual thread due to the JDK version.
-        int javaRelease = Integer.parseInt(System.getProperty("java.specification.version"));
+        int javaRelease;
+        try {
+            javaRelease = Integer.parseInt(System.getProperty("java.specification.version"));
+        } catch (NumberFormatException ex) {
+            Logger.getLogger("discord.jar-threading")
+                    .warning("Could not parse java.specification.version, falling back to normal threads. This is usually a bug, so please report the following string to the discord.jar developers: " + System.getProperty("java.specification.version"));
+            return requestThread(runnable, name);
+        }
         if (javaRelease < 21) {
             Logger.getLogger("discord.jar-threading")
                     .warning("discord.jar virtual threads are only supported on JDK 21 and above, falling back to normal threads. It's recommended, if possible, that you upgrade your JDK to 21 or above.");


### PR DESCRIPTION
## PR Details
- [x] I have checked the PRs for upcoming features/bug fixes.

### What you've changed

- [ ] Developer-facing library
- [x] Internal Code
- [ ] Documentation

## Description
Java 21 adds support for [Project Loom's Virtual Threads](https://docs.oracle.com/en/java/javase/20/core/virtual-threads.html), a new type of Thread that doesn't use an OS thread, rather a custom thread created by the JVM, therefore being useful for large quantities of Thread creation.

This PR updates the pom.xml to add support for Java 21, including updating other dependencies. It also updates the DiscordJarThreadAllocator class to create a new method, `requestVirtualThread` which will return a running virtual thread, similar to the `requestThread` method.

This should be backwards-compatible with older versions of Java, as discord.jar will check that the Java release version is 21 or higher before attempting to use virtual threads. It is, however, recommended that you do update your version, especially for larger applications or those with many intents enabled.

Virtual Threads are mainly intended to be used by the Gateway implementation but can also be included in other high throughput parts of the code.